### PR TITLE
CodeMergeRequestEvent models

### DIFF
--- a/gems/icalia-sdk-event-core/icalia-sdk-event-core.gemspec
+++ b/gems/icalia-sdk-event-core/icalia-sdk-event-core.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
 
   spec.add_dependency 'jsonapi-deserializable', '~> 0.2.0'
+  spec.add_dependency 'activemodel', '>= 5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'icalia-sdk-event-core/version'
+require 'icalia-sdk-event-core/models'
 require 'icalia-sdk-event-core/serialization'
 
 module Icalia::Event

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Icalia
+  models_path = 'icalia-sdk-event-core/models'
+  
+  autoload :ModelBase, "#{models_path}/model_base"
+  autoload :ModelProxy, "#{models_path}/model_proxy"
+
+
+  autoload :ResourceIdentity, "#{models_path}/resource_identity"
+  autoload :ResourceAction, "#{models_path}/resource_action"
+  autoload :ResourceTimestamps, "#{models_path}/resource_timestamps"
+
+  # Core Models:
+  autoload :Person, "#{models_path}/person"
+
+  autoload :CodeCommit, "#{models_path}/code_commit"
+  autoload :CodeRepository, "#{models_path}/code_repository"
+  autoload :CodeCommitReference, "#{models_path}/code_commit_reference"
+
+  autoload :CodeMergeRequest, "#{models_path}/code_merge_request"
+
+  # Event Models:
+  autoload :CodeMergeRequestEvent, "#{models_path}/code_merge_request_event"
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/cloud_identity.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/cloud_identity.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Icalia
+  class CloudIdentity < ModelBase
+    attr_reader :provider,
+                :id_at_provider,
+                :created_at,
+                :updated_at,
+                :name,
+                :identity_type
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_commit.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_commit.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Icalia
+  class CodeCommit < ModelBase
+    attr_reader :sha
+
+    attr_reader :repository
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_commit_reference.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_commit_reference.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Icalia
+  class CodeCommitReference < ModelBase
+    include ResourceIdentity
+    attr_reader :name, :label
+
+    attr_reader :commit
+
+    delegate :repository, to: :commit, allow_nil: true
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_merge_request.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_merge_request.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Icalia
+  class CodeMergeRequest < ModelBase
+    attr_reader :number,
+                :provider,
+                :id_at_provider,
+                :created_at,
+                :updated_at,
+                :number,
+                :body,
+                :state,
+                :title,
+                :url,
+                :additions,
+                :deletions,
+                :added_line_count,
+                :deleted_line_count,
+                :changed_file_count
+
+    attr_reader :base, :head, :author, :committer
+
+    def closed?; state == 'closed'; end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_merge_request_event.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_merge_request_event.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Icalia
+  class CodeMergeRequestEvent < ModelBase
+    include ResourceAction
+    attr_reader :merge_request
+
+    def closed?; action == 'closed'; end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_repository.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_repository.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Icalia
+  class CodeRepository < ModelBase
+    include ResourceIdentity
+    
+    attr_reader :owner # DeserializablePropertyResource   # has one owner
+
+    attr_reader :created_at # include DeserializableResourceCreationTimestamp
+
+    attr_reader :name, :private, :fork, :provider, :description, :url, :fork,
+                :exists, :archived, :html_url, :full_name, :id_at_provider,
+                :default_branch
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/model_base.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/model_base.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'active_model'
+
+module Icalia
+  class ModelBase
+    extend ActiveModel::Naming
+    include ResourceIdentity
+
+    attr_reader :serialization_context
+
+    def initialize(object_attributes = {})
+      @serialization_context = object_attributes.delete :serialization_context
+      
+      object_attributes.each do |key, value|
+        attribute_name = "#{key}".underscore
+        next register_stand_in(attribute_name, value) if value.is_a? ModelProxy
+        instance_variable_set("@#{attribute_name}", value)
+      end
+    end
+
+    private
+
+    def register_stand_in(association, stand_in)
+      instance_variable_set("@#{association}", stand_in)
+      serialization_context.register_stand_in model: self,
+                                              stand_in: stand_in,
+                                              association: association
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/model_proxy.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/model_proxy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Icalia
+  # ModelProxy: Acts as a stand-in for an associated model, which may be
+  # awaiting for de-serialization at the time the parent object was being 
+  # de-serialized
+  class ModelProxy
+    include ResourceIdentity
+
+    def initialize(id:, type:)
+      @id = id
+      @type = type
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/organization.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/organization.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Icalia
+  class Organization < ModelBase
+    include ResourceTimestamps
+    attr_reader :name
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Icalia
+  class Person < ModelBase
+    include ResourceTimestamps
+    attr_reader :name
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/resource_action.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/resource_action.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icalia
+  module ResourceAction
+    extend ActiveSupport::Concern
+    
+    included do
+      attr_reader :action, :actor, :timestamp
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/resource_identity.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/resource_identity.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Icalia
+  module ResourceIdentity
+    extend ActiveSupport::Concern
+    
+    included do
+      attr_reader :id, :type
+    end
+
+    def to_key
+      { id: id, type: type }
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/resource_timestamps.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/resource_timestamps.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icalia
+  module ResourceTimestamps
+    extend ActiveSupport::Concern
+    
+    included do
+      attr_reader :created_at, :updated_at
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
@@ -6,6 +6,8 @@ module Icalia
   module Event
     serialization_path = "icalia-sdk-event-core/serialization"
 
+    autoload :Deserializer, "#{serialization_path}/deserializer"
+
     # Deserialization Modules:
     autoload :DeserializableResourceIdentity,
              "#{serialization_path}/deserializable_resource_identity"

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'jsonapi/deserializable'
+
 module Icalia
   module Event
     serialization_path = "icalia-sdk-event-core/serialization"

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
@@ -57,6 +57,18 @@ module Icalia
     autoload :DeserializableCodeRepositoryEvent,
              "#{serialization_path}/deserializable_code_repository_event"
 
+    autoload :DeserializableCodeMergeRequest,
+             "#{serialization_path}/deserializable_code_merge_request"
+
+    autoload :DeserializableCodeMergeRequestEvent,
+             "#{serialization_path}/deserializable_code_merge_request_event"
+
+    autoload :DeserializableCodeCommit,
+             "#{serialization_path}/deserializable_code_commit"
+
+    autoload :DeserializableCodeCommitReference,
+             "#{serialization_path}/deserializable_code_commit_reference"
+
     autoload :DeserializableCodeRepository,
              "#{serialization_path}/deserializable_code_repository"
 

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_commit.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_commit.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Icalia::Event
+  #= DeserializableCodeCommit
+  #
+  # This class is responsible for converting a JSONAPI.org representation of an
+  # Icalia `CodeCommitReference` object
+  class DeserializableCodeCommit < JSONAPI::Deserializable::Resource
+    include DeserializableResourceIdentity   # id and type
+
+    attributes :sha
+
+    has_one(:repository) do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[repository: stand_in]
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_commit_reference.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_commit_reference.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Icalia::Event
+  #= DeserializableCodeCommitReference
+  #
+  # This class is responsible for converting a JSONAPI.org representation of an
+  # Icalia `CodeCommitReference` object
+  class DeserializableCodeCommitReference < JSONAPI::Deserializable::Resource
+    include DeserializableResourceIdentity   # id and type
+
+    attributes :name, :label
+
+    has_one(:commit) do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[commit: stand_in]
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_merge_request.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_merge_request.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Icalia::Event
+  #= DeserializableCodeMergeRequest
+  #
+  # This class is responsible for converting a JSONAPI.org representation of an
+  # Icalia Event's `CodeMergeRequestEvent` object that can be used to create or
+  # update a code-repository data
+  class DeserializableCodeMergeRequest < JSONAPI::Deserializable::Resource
+    include DeserializableResourceIdentity
+    include DeserializableResourceTimestamps
+
+    attributes :number, :provider, :body, :state, :title, :url, :additions, :deletions
+
+    attribute(:'id-at-provider') { |value| Hash[id_at_provider: value] }
+    attribute(:'added-line-count') { |value| Hash[added_line_count: value] }
+    attribute(:'deleted-line-count') { |value| Hash[deleted_line_count: value] }
+    attribute(:'changed-line-count') { |value| Hash[changed_line_count: value] }
+
+    has_one :author do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[author: stand_in]
+    end
+
+    has_one :base do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[base: stand_in]
+    end
+
+    has_one :head do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[head: stand_in]
+    end
+
+    has_one :committer do |rel, id, type|
+      next Hash[committer: nil] unless rel[:data].present?
+      
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[committer: stand_in]
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_merge_request_event.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_merge_request_event.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Icalia::Event
+  #= DeserializableCodeMergeRequestEvent
+  #
+  # This class is responsible for converting a JSONAPI.org representation of an
+  # Icalia Event's `CodeMergeRequestEvent` object that can be used to create or
+  # update a code-repository data
+  class DeserializableCodeMergeRequestEvent < JSONAPI::Deserializable::Resource
+    include DeserializableResourceIdentity
+    include DeserializableResourceAction
+
+    has_one :'merge-request' do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[merge_request: stand_in]
+    end
+  end
+end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_repository.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_repository.rb
@@ -10,6 +10,18 @@ module Icalia::Event
     include DeserializablePropertyResource   # has one owner
     include DeserializableResourceCreationTimestamp
 
-    attributes :name, :private, :fork, :'default-branch'
+    attributes :name, :private, :fork, :provider, :description, :url, :fork,
+               :exists, :archived
+
+    attribute(:'html-url') { |value| Hash[html_url: value]}
+    attribute(:'full-name') { |value| Hash[full_name: value] }
+    
+    attribute(:'id-at-provider') { |value| Hash[id_at_provider: value] }
+    attribute(:'default-branch') { |value| Hash[default_branch: value] }
+
+    has_one :owner do |_rel, id, type|
+      stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+      Hash[owner: stand_in]
+    end
   end
 end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_resource_action.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_resource_action.rb
@@ -6,6 +6,12 @@ module Icalia::Event
 
     included do
       attribute(:action) { |value| Hash[action: value] }
+      attribute(:timestamp) { |value| Hash[timestamp: Time.parse(value)] }
+
+      has_one :actor do |_rel, id, type|
+        stand_in = Icalia::ModelProxy.new id: id, type: classify_type(type)
+        Hash[actor: stand_in]
+      end
     end
   end
 end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_resource_creation_timestamp.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_resource_creation_timestamp.rb
@@ -5,7 +5,7 @@ module Icalia::Event
     extend ActiveSupport::Concern
 
     included do
-      attribute(:'created-at') { |value| Hash[created_at: value] }
+      attribute(:'created-at') { |value| Hash[created_at: Time.parse(value)] }
     end
   end
 end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_resource_timestamps.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_resource_timestamps.rb
@@ -6,7 +6,7 @@ module Icalia::Event
 
     included do
       include DeserializableResourceCreationTimestamp
-      attribute(:'updated-at') { |value| Hash[updated_at: value] }
+      attribute(:'updated-at') { |value| Hash[updated_at: Time.parse(value)] }
     end
   end
 end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializer.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializer.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Icalia::Event
+  class Deserializer
+    attr_reader :data
+
+    class StandInReplacement
+      attr_reader :model, :association, :stand_in
+      
+      def initialize(model:, association:, stand_in:)
+        @model = model
+        @association = association
+        @stand_in = stand_in
+      end
+    end
+    
+    def initialize(jsonapi_data)
+      @jsonapi_data = jsonapi_data
+      @objects = {}
+      @pending_stand_in_replacements = []
+    end
+
+    def perform
+      return @data if @data.present?
+      deserialize_included
+      deserialize_data
+      replace_stand_ins
+      finalize
+      @data
+    end
+
+    def register_stand_in(model:, association:, stand_in:)
+      @pending_stand_in_replacements << StandInReplacement.new(
+        model: model,
+        association: association,
+        stand_in: stand_in
+      )
+    end
+
+    def to_s
+      '(...to_s...)'
+    end
+
+    def inspect
+      '(...inspect...)'
+    end
+
+    private
+
+    def replace_stand_ins
+      @pending_stand_in_replacements.each do |replacement|
+        associated_object = @objects[replacement.stand_in.to_key]
+        next unless associated_object.present?
+        variable = "@#{replacement.association}".to_sym
+        replacement.model.instance_variable_set(variable, associated_object)
+      end
+    end
+
+    def finalize
+      # debugger
+    end
+
+    def deserialize_included
+      @jsonapi_data.fetch('included', []).each do |object_data|
+        if object = deserialize_object_data(object_data)
+          add_object_to_index object
+        end
+      end
+    end
+
+    def add_object_to_index(object)
+      @objects[object.to_key] = object
+    end
+
+    def deserialize_data
+      root_data = @jsonapi_data.fetch('data')
+      if @data = add_object_to_index(deserialize_object_data(root_data))
+        add_object_to_index @data
+      end
+    end
+
+    def deserialize_object_data(object_data)
+      object_class_name = object_data['type'].underscore.classify
+      object_class = "::Icalia::#{object_class_name}".safe_constantize
+      return unless object_class.present?
+      
+      deserializer_class = "::Icalia::Event::Deserializable#{object_class_name}".safe_constantize
+      return unless deserializer_class.present?
+      
+      object_attributes = deserializer_class
+        .call(object_data)
+        .merge(serialization_context: self)
+
+      object_class.new object_attributes
+    end
+  end
+end


### PR DESCRIPTION
# What does this PR do?

* Adds models that should be received as events by the app using `icalia-sdk-event-*` gems
* Adds deserialization to be used to build model objects on event notification/webhook