### PR TITLE
Fix event models

### DIFF
--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models.rb
@@ -13,6 +13,7 @@ module Icalia
 
   # Core Models:
   autoload :Person, "#{models_path}/person"
+  autoload :Organization, "#{models_path}/organization"
 
   autoload :CodeCommit, "#{models_path}/code_commit"
   autoload :CodeRepository, "#{models_path}/code_repository"

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models.rb
@@ -16,7 +16,7 @@ module Icalia
 
   autoload :CodeCommit, "#{models_path}/code_commit"
   autoload :CodeRepository, "#{models_path}/code_repository"
-  autoload :CodeCommitReference, "#{models_path}/code_commit_reference"
+  autoload :CodeRepositoryReference, "#{models_path}/code_repository_reference"
 
   autoload :CodeMergeRequest, "#{models_path}/code_merge_request"
 

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_merge_request_event.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_merge_request_event.rb
@@ -5,6 +5,9 @@ module Icalia
     include ResourceAction
     attr_reader :merge_request
 
-    def closed?; action == 'closed'; end
+    def opened?; action == 'opened'; end
+    def updated?; action == 'updated'; end
+    def merged?; action == 'merged'; end
+    def declined?; action == 'declined'; end
   end
 end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_repository_reference.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/code_repository_reference.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module Icalia
-  class CodeCommitReference < ModelBase
+  class CodeRepositoryReference < ModelBase
     include ResourceIdentity
     attr_reader :name, :label
 
     attr_reader :commit
 
-    delegate :repository, to: :commit, allow_nil: true
+    delegate :sha, :repository, to: :commit, allow_nil: true
   end
 end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization.rb
@@ -70,11 +70,11 @@ module Icalia
     autoload :DeserializableCodeCommit,
              "#{serialization_path}/deserializable_code_commit"
 
-    autoload :DeserializableCodeCommitReference,
-             "#{serialization_path}/deserializable_code_commit_reference"
-
     autoload :DeserializableCodeRepository,
              "#{serialization_path}/deserializable_code_repository"
+
+    autoload :DeserializableCodeRepositoryReference,
+             "#{serialization_path}/deserializable_code_repository_reference"
 
     autoload :DeserializableCloudIdentity,
              "#{serialization_path}/deserializable_cloud_identity"

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_repository_reference.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_code_repository_reference.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module Icalia::Event
-  #= DeserializableCodeCommitReference
+  #= DeserializableCodeRepositoryReference
   #
   # This class is responsible for converting a JSONAPI.org representation of an
-  # Icalia `CodeCommitReference` object
-  class DeserializableCodeCommitReference < JSONAPI::Deserializable::Resource
-    include DeserializableResourceIdentity   # id and type
+  # Icalia `CodeRepositoryReference` object
+  class DeserializableCodeRepositoryReference < JSONAPI::Deserializable::Resource
+    include DeserializableResourceIdentity # id and type
 
     attributes :name, :label
 

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_organization.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/serialization/deserializable_organization.rb
@@ -10,6 +10,6 @@ module Icalia::Event
     include DeserializablePropertyResource   # has one owner
     include DeserializableResourceTimestamps # created_at and updated_at
 
-    attributes :name, :email
+    attributes :name
   end
 end


### PR DESCRIPTION
* Renames `Icalia::CodeCommitReference` model to `Icalia::CodeRepositoryReference`
* Fixes loading of `Icalia::Organization` model
* Removes `email` attribute from `Icalia::Organization` deserialization
* Adds `opened?`, `updated?`, `merged?` and `declined?` methods to `CodeMergeRequestEvent`