### PR TITLE
Person missing details fields

### DIFF
--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
@@ -3,7 +3,9 @@
 module Icalia
   class Person < ModelBase
     include ResourceTimestamps
-    attr_reader :name
+    attr_reader :full_name, :given_name, :family_name
+
+    alias name full_name
 
     has_many :email_accounts, :cloud_identities
   end

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
@@ -4,7 +4,8 @@ module Icalia
   class Person < ModelBase
     include ResourceTimestamps
     attr_reader :full_name, :given_name, :family_name,
-                :gender_type, :custom_gender
+                :gender_type, :custom_gender,
+                :date_of_birth
 
     alias name full_name
 

--- a/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
+++ b/gems/icalia-sdk-event-core/lib/icalia-sdk-event-core/models/person.rb
@@ -3,7 +3,8 @@
 module Icalia
   class Person < ModelBase
     include ResourceTimestamps
-    attr_reader :full_name, :given_name, :family_name
+    attr_reader :full_name, :given_name, :family_name,
+                :gender_type, :custom_gender
 
     alias name full_name
 


### PR DESCRIPTION
Adds these fields to the Person model﻿:

* `#full_name`
* `#given_name`
* `#family_name`
* `#gender_type`
* `#custom_gender`
* `#date_of_birth`

Also, we kept `Person#name` as an alias for `Person#full_name`
