### PR TITLE
Fix core rake 'release' task not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Ignore temporary files
 tmp/*
+
+# Ignore gem builds
+**/pkg/*.gem

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -3,4 +3,9 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
+
+# Override the :release task to skip the release:guard_clean and 
+# release:source_control_push tasks, which are not feasible in our CI/CD
+# context:
+task :release, [:remote] => %w[build release:rubygem_push]

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -8,4 +8,5 @@ task default: :spec
 # Override the :release task to skip the release:guard_clean and 
 # release:source_control_push tasks, which are not feasible in our CI/CD
 # context:
+Rake::Task['release'].clear
 task :release, [:remote] => %w[build release:rubygem_push]

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -1,5 +1,5 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -9,4 +9,4 @@ task default: :spec
 # release:source_control_push tasks, which are not feasible in our CI/CD
 # context:
 Rake::Task['release'].clear
-task :release, [:remote] => %w[build release:rubygem_push]
+task :release, %i[remote] => %w[build release:rubygem_push]

--- a/event-notification/Rakefile
+++ b/event-notification/Rakefile
@@ -1,18 +1,12 @@
-$LOAD_PATH.unshift File.expand_path('./lib', __dir__)
-
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'icalia-sdk-event-notification/version'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
 
-desc "Build icalia-sdk-event-notification-#{Icalia::SDK::EVENT_NOTIFICATION_VERSION}.gem"
-task :build do
-  system 'gem build icalia-sdk-event-notification.gemspec'
-end
-
-desc "Build and push icalia-sdk-event-notification-#{Icalia::SDK::EVENT_NOTIFICATION_VERSION}.gem"
-task release: :build do
-  system "gem push icalia-sdk-event-notification-#{Icalia::SDK::EVENT_NOTIFICATION_VERSION}.gem"
-end
+# Override the :release task to skip the release:guard_clean and 
+# release:source_control_push tasks, which are not feasible in our CI/CD
+# context:
+Rake::Task['release'].clear
+task :release, %i[remote] => %w[build release:rubygem_push]

--- a/event-webhook/Rakefile
+++ b/event-webhook/Rakefile
@@ -1,18 +1,12 @@
-$LOAD_PATH.unshift File.expand_path('./lib', __dir__)
-
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'icalia-sdk-event-webhook/version'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
 
-desc "Build icalia-sdk-event-webhook-#{Icalia::SDK::EVENT_WEBHOOK_VERSION}.gem"
-task :build do
-  system 'gem build icalia-sdk-event-webhook.gemspec'
-end
-
-desc "Build and push icalia-sdk-event-webhook-#{Icalia::SDK::EVENT_WEBHOOK_VERSION}.gem"
-task release: :build do
-  system "gem push icalia-sdk-event-webhook-#{Icalia::SDK::EVENT_WEBHOOK_VERSION}.gem"
-end
+# Override the :release task to skip the release:guard_clean and 
+# release:source_control_push tasks, which are not feasible in our CI/CD
+# context:
+Rake::Task['release'].clear
+task :release, %i[remote] => %w[build release:rubygem_push]

--- a/event/Rakefile
+++ b/event/Rakefile
@@ -1,18 +1,12 @@
-$LOAD_PATH.unshift File.expand_path('./lib', __dir__)
-
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'icalia-sdk-event/version'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
 
-desc "Build icalia-sdk-event-#{Icalia::SDK::EVENT_VERSION}.gem"
-task :build do
-  system 'gem build icalia-sdk-event.gemspec'
-end
-
-desc "Build and push icalia-sdk-event-#{Icalia::SDK::EVENT_VERSION}.gem"
-task release: :build do
-  system "gem push icalia-sdk-event-#{Icalia::SDK::EVENT_VERSION}.gem"
-end
+# Override the :release task to skip the release:guard_clean and 
+# release:source_control_push tasks, which are not feasible in our CI/CD
+# context:
+Rake::Task['release'].clear
+task :release, %i[remote] => %w[build release:rubygem_push]

--- a/sdk/Rakefile
+++ b/sdk/Rakefile
@@ -1,18 +1,12 @@
-$LOAD_PATH.unshift File.expand_path('./lib', __dir__)
-
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'icalia-sdk/version'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
 
-desc "Build icalia-sdk-#{Icalia::SDK::META_VERSION}.gem"
-task :build do
-  system 'gem build icalia-sdk.gemspec'
-end
-
-desc "Build and push icalia-sdk-#{Icalia::SDK::META_VERSION}.gem"
-task release: :build do
-  system "gem push icalia-sdk-#{Icalia::SDK::META_VERSION}.gem"
-end
+# Override the :release task to skip the release:guard_clean and 
+# release:source_control_push tasks, which are not feasible in our CI/CD
+# context:
+Rake::Task['release'].clear
+task :release, %i[remote] => %w[build release:rubygem_push]


### PR DESCRIPTION

# What does this PR do?

- Updates the `icalia-sdk-core` Rakefile to override the `release` task so it skips the git checking & tagging
- Updates the rest of the rakefiles with the same content.﻿
